### PR TITLE
Cache

### DIFF
--- a/include/VerificationValidationWidget.h
+++ b/include/VerificationValidationWidget.h
@@ -84,8 +84,6 @@ private:
     // widget-specific data
     Document *document;
     QString modelID;
-    QString dbFilePath;
-    QString dbName;
     QString dbConnectionName;
 
     // user interface data
@@ -122,7 +120,7 @@ private:
     std::map<int, QListWidgetItem*> idToItemMap;
 
     // init functions
-    void dbConnect(QString dbFilePath);
+    void dbConnect(QString& dbFilePath);
     void dbInitTables();
     void dbPopulateDefaults();
     void setupUI();

--- a/include/VerificationValidationWidget.h
+++ b/include/VerificationValidationWidget.h
@@ -10,6 +10,7 @@
 #include <QtSql/QSqlTableModel>
 #include <QtSql/QSqlQuery>
 #include <QtSql/QSqlError>
+#include <bu/app.h>
 #include <QtWidgets>
 #include <QMessageBox>
 #include <QHBoxWidget.h>
@@ -78,7 +79,7 @@ private:
     MainWindow *mainWindow;
     Dockable *parentDockable;
     int msgBoxRes;
-    QString folderName;
+    QString cacheFolder;
 
     // widget-specific data
     Document *document;


### PR DESCRIPTION
- atr files now located in user's BRL-CAD cache
- atr files now mapped based on UUID (fixes same name, different file contents bug)
- deprecated unnecessary class variables